### PR TITLE
fix a little mistake. may be a clerical error

### DIFF
--- a/example6/readme.org
+++ b/example6/readme.org
@@ -2,7 +2,7 @@
 Before start, you need download  Centos7 RPM package from Pviotal ( https://network.pivotal.io/products/pivotal-gpdb/ ) and save it in this folder.
 ** Build docker image
 #+BEGIN_SRC bash
-docker build . -t mygreenplum
+docker build . -t mygreenplum6
 #+END_SRC
 ** Modify Cluster config
 ** Start container


### PR DESCRIPTION
In README file,
like this, `docker build . -t mygreenplum`
but in the `docker-compose.yaml` there **image** name was `mygreenplum6`
