### PR TITLE
Update Dockerfile - epel-release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@
 FROM centos:centos7
 
 RUN yum -y update
+RUN yum -y install epel-release
 RUN yum -y install openssh-server passwd bash sudo \
-        epel-release xerces-c which openssh-clients \
+                xerces-c which openssh-clients \
 		net-tools less iproute m4 libevent apr-util \
 		python-pip python-psutil python2-lockfile python-paramiko \
 		&& yum clean all && rm -rf /var/cache/yum


### PR DESCRIPTION
"epel-release" has to be installed BEFORE installing "python-pip". "python-psutil", ... There is no error but the log will say "No package for python-pip" etc.